### PR TITLE
First Draft for Anthropic service

### DIFF
--- a/lionagi/_services/anthropic.py
+++ b/lionagi/_services/anthropic.py
@@ -1,1 +1,68 @@
-# TODO
+import asyncio
+from os import getenv
+from typing import Dict, Any
+
+
+
+class AnthropicService:
+    base_url = "https://api.anthropic.com/v1/"
+    available_endpoints = ['chat/completions']
+    schema = {}  # Define the schema according to Anthropic's API documentation
+    key_scheme = "ANTHROPIC_API_KEY"
+    token_encoding_name = "cl100k_base"
+    
+    def __init__(self, api_key=None, schema=None, token_encoding_name="cl100k_base", **kwargs):
+        self.api_key = api_key or getenv(self.key_scheme)
+        self.schema = schema or self.schema
+        self.token_encoding_name = token_encoding_name
+        self.active_endpoints = set()
+        self.status_tracker = StatusTracker()
+
+    async def init_endpoint(self, endpoint):
+        # Initialize the endpoint with its own rate limiter, etc.
+        if endpoint in self.available_endpoints and endpoint not in self.active_endpoints:
+            # Assuming RateLimiter is a context manager handling the rate limits
+            self.active_endpoints.add(endpoint)
+            # Setup any additional initialization if required by the endpoint
+
+    async def serve(self, input_, endpoint="chat/completions", method="post", **kwargs):
+        if endpoint not in self.active_endpoints:
+            await self.init_endpoint(endpoint)
+        if endpoint == "chat/completions":
+            return await self.serve_chat(input_, **kwargs)
+        else:
+            raise ValueError(f'{endpoint} is currently not supported')
+    
+    async def serve_chat(self, messages, **kwargs):
+        endpoint = "chat/completions"
+        payload = self.create_payload(messages, self.schema[endpoint], **kwargs)
+
+        try:
+            response = await self.call_api(payload, endpoint, method="post")
+            self.status_tracker.num_tasks_succeeded += 1
+            return payload, response
+        except Exception as e:
+            self.status_tracker.num_tasks_failed += 1
+            raise e
+
+    async def call_api(self, payload, endpoint, method):
+        # This method should handle the API call logic, including creating an HTTP session
+        # and handling the request/response cycle.
+
+    
+        def create_payload(self, messages, schema, **kwargs):
+        # Generate the payload based on the messages, schema, and any additional arguments
+            return PayloadCreation.chat_completion(
+            messages, self.schema[endpoint], **kwargs)
+
+# Usage example
+async def main():
+    anthropic_service = AnthropicService(api_key='your_api_key')
+
+    prompt = "Hello, Claude. I would like to know about your capabilities."
+    response = await anthropic_service.serve(prompt, endpoint="chat/completions")
+    print(response)
+
+# Run the event loop
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/lionagi/_services/anthropic.py
+++ b/lionagi/_services/anthropic.py
@@ -1,68 +1,79 @@
-import asyncio
 from os import getenv
-from typing import Dict, Any
+from .base_service import BaseService, PayloadCreation
 
+class AnthropicService(BaseService):
+    """
+    A service to interact with Anthropic's API endpoints.
 
+    Attributes:
+        base_url (str): The base URL for the OpenAI API.
+        available_endpoints (list): A list of available API endpoints.
+        schema (dict): The schema configuration for the API.
+        key_scheme (str): The environment variable name for OpenAI API key.
+        token_encoding_name (str): The default token encoding scheme.
 
-class AnthropicService:
+    Examples:
+        >>> service = AnthropicService(api_key="your_api_key")
+        >>> asyncio.run(service.serve("Hello, world!", "chat/completions"))
+        (payload, completion)
+    """
+
     base_url = "https://api.anthropic.com/v1/"
     available_endpoints = ['chat/completions']
-    schema = {}  # Define the schema according to Anthropic's API documentation
+    schema = {}        # TODO
     key_scheme = "ANTHROPIC_API_KEY"
     token_encoding_name = "cl100k_base"
-    
-    def __init__(self, api_key=None, schema=None, token_encoding_name="cl100k_base", **kwargs):
-        self.api_key = api_key or getenv(self.key_scheme)
-        self.schema = schema or self.schema
-        self.token_encoding_name = token_encoding_name
-        self.active_endpoints = set()
-        self.status_tracker = StatusTracker()
 
-    async def init_endpoint(self, endpoint):
-        # Initialize the endpoint with its own rate limiter, etc.
-        if endpoint in self.available_endpoints and endpoint not in self.active_endpoints:
-            # Assuming RateLimiter is a context manager handling the rate limits
-            self.active_endpoints.add(endpoint)
-            # Setup any additional initialization if required by the endpoint
+    def __init__(self, api_key = None, key_scheme = None,schema = None, token_encoding_name: str = "cl100k_base", **kwargs):
+        key_scheme = key_scheme or self.key_scheme            
+        super().__init__(
+            api_key = api_key or getenv(key_scheme),
+            schema = schema or self.schema,
+            token_encoding_name=token_encoding_name, 
+            **kwargs
+        )
+        self.active_endpoint = []
 
     async def serve(self, input_, endpoint="chat/completions", method="post", **kwargs):
-        if endpoint not in self.active_endpoints:
-            await self.init_endpoint(endpoint)
+        """
+        Serves the input using the specified endpoint and method.
+
+        Args:
+            input_: The input text to be processed.
+            endpoint: The API endpoint to use for processing.
+            method: The HTTP method to use for the request.
+            **kwargs: Additional keyword arguments to pass to the payload creation.
+
+        Returns:
+            A tuple containing the payload and the completion response from the API.
+        """
+        if endpoint not in self.active_endpoint:
+            await self. init_endpoint(endpoint)
         if endpoint == "chat/completions":
             return await self.serve_chat(input_, **kwargs)
         else:
-            raise ValueError(f'{endpoint} is currently not supported')
+            return ValueError(f'{endpoint} is currently not supported')
     
     async def serve_chat(self, messages, **kwargs):
-        endpoint = "chat/completions"
-        payload = self.create_payload(messages, self.schema[endpoint], **kwargs)
+        """
+        Serves the chat completion request with the given messages.
+
+        Args:
+            messages: The messages to be included in the chat completion.
+            **kwargs: Additional keyword arguments for payload creation.
+
+        Returns:
+            A tuple containing the payload and the completion response from the API.
+        """
+        if "chat/completions" not in self.active_endpoint:
+            await self. init_endpoint("chat/completions")
+            self.active_endpoint.append("chat/completions")
+        payload = PayloadCreation.chat_completion(
+            messages, self.endpoints["chat/completions"].config, self.schema["chat/completions"], **kwargs)
 
         try:
-            response = await self.call_api(payload, endpoint, method="post")
-            self.status_tracker.num_tasks_succeeded += 1
-            return payload, response
+            completion = await self.call_api(payload, "chat/completions", "post")
+            return payload, completion
         except Exception as e:
             self.status_tracker.num_tasks_failed += 1
             raise e
-
-    async def call_api(self, payload, endpoint, method):
-        # This method should handle the API call logic, including creating an HTTP session
-        # and handling the request/response cycle.
-
-    
-        def create_payload(self, messages, schema, **kwargs):
-        # Generate the payload based on the messages, schema, and any additional arguments
-            return PayloadCreation.chat_completion(
-            messages, self.schema[endpoint], **kwargs)
-
-# Usage example
-async def main():
-    anthropic_service = AnthropicService(api_key='your_api_key')
-
-    prompt = "Hello, Claude. I would like to know about your capabilities."
-    response = await anthropic_service.serve(prompt, endpoint="chat/completions")
-    print(response)
-
-# Run the event loop
-if __name__ == '__main__':
-    asyncio.run(main())


### PR DESCRIPTION
### Documentation for AnthropicService Python Module

This Python module provides an asynchronous interface to interact with the Anthropic API, specifically targeting the `chat/completions` endpoint. It is designed to encapsulate the process of making API requests, handling rate limits, and processing responses.

**Requirements**

- Python 3.7+
- `aiohttp` library for asynchronous HTTP requests
- Access to Anthropic API and a valid API key

### Configuration

Before using the `AnthropicService`, you need to obtain an API key from Anthropic. Once acquired, you can set it as an environment variable `ANTHROPIC_API_KEY` or pass it directly to the `AnthropicService` constructor.

**Module Components**

**AnthropicService Class**

This class provides methods to interact with the Anthropic API.

1. Attributes

- `base_url` (str): The base URL for the Anthropic API.
- `available_endpoints` (list): A list of available API endpoints.
- `schema` (dict): The schema defining the structure for API requests. Needs to be defined according to Anthropic's API documentation.
- `key_scheme` (str): Environment variable key name for the API key.
- `token_encoding_name` (str): Encoding scheme used for rate limiting tokens.

2. Methods

- `__init__(api_key=None, schema=None, token_encoding_name="cl100k_base", **kwargs)`: Initializes the service with an API key, request schema, and token encoding name.
- `async init_endpoint(endpoint)`: Initializes an API endpoint, setting up any required rate limiters or other configurations.
- `async serve(input_, endpoint="chat/completions", method="post", **kwargs)`: High-level method to serve requests. It initializes endpoints as needed and directs to the appropriate service method based on the endpoint.
- `async serve_chat(messages, **kwargs)`: Handles requests to the `chat/completions` endpoint.
- `async call_api(payload, endpoint, method)`: Makes the API call. Implementers need to fill in this method with `aiohttp` or another HTTP client library to perform the actual network request.
- `create_payload(messages, schema, **kwargs)`: Generates the payload for the API request based on input messages and the provided schema.

### Usage Example

```python
import asyncio

async def main():
    anthropic_service = AnthropicService(api_key='your_api_key_here')
    prompt = "Hello, Claude. I would like to know about your capabilities."
    response = await anthropic_service.serve(prompt, endpoint="chat/completions")
    print(response)

if __name__ == '__main__':
    asyncio.run(main())
```

### Notes

- Replace `'your_api_key_here'` with your actual Anthropic API key.
- The `call_api` method needs to be implemented to perform HTTP requests.
- This module is designed to be extended with additional functionality, such as more endpoints or sophisticated error handling.

**Error Handling**

The module raises a `ValueError` if an unsupported endpoint is requested. Implementers should add try-except blocks to handle network errors, API rate limiting, and other exceptions that might occur during API calls.

**Extending the Module**

To support more endpoints or add features:
- Update `available_endpoints` with new endpoints.
- Extend the schema to include new request formats.
- Implement additional methods similar to `serve_chat` for other endpoints.

Remember to review Anthropic's API documentation for the latest endpoints, request formats, and best practices.